### PR TITLE
added Igbo-English MT + monolingual datasets

### DIFF
--- a/list-of-datasets.md
+++ b/list-of-datasets.md
@@ -12,6 +12,7 @@
 |  English-Afrikaans   |  [Autshumato Corpus](https://repo.sadilar.org/handle/20.500.12185/397)  |
 | English-isiXhosa | [Navy Corpus](http://opus.nlpl.eu/XhosaNavy.php) |
 | Lingala-French | [Lingala Song Lyrics](https://github.com/espoirMur/songs_lyrics_webscrap) |
+| Igbo-English | [Igbo-English Evaluation Benchmark](https://github.com/IgnatiusEzeani/IGBONLP/tree/master/ig_en_mt) |
 
 
 ## Monolingual
@@ -25,6 +26,7 @@
 |  isiZulu    |  [African Speech Technology](https://rma.nwu.ac.za/index.php/resource-catalogue/ast-corpus-isizulu.html)  |
 |  isiZulu    |  [Zulu Bible](https://raw.githubusercontent.com/christos-c/bible-corpus/master/bibles/Zulu-NT.xml) (to be scraped) |
 |  isiZulu    |  [Zulu Quoran](http://idmdawah.co.za/wp-content/uploads/2015/07/zulu-quran1.pdf) (to be scraped) |
+|  Igbo    |  [Igbo Monolingual Dataset (~384k sents)](https://github.com/IgnatiusEzeani/IGBONLP/tree/master/ig_monoling)|
 
 
 ## Named Entity Recognition


### PR DESCRIPTION
Please kindly cite as below:
@misc{ezeani2020igboenglish,
    title={Igbo-English Machine Translation: An Evaluation Benchmark},
    author={Ignatius Ezeani and Paul Rayson and Ikechukwu Onyenwe and Chinedu Uchechukwu and Mark Hepple},
    year={2020},
    eprint={2004.00648},
    archivePrefix={arXiv},
    primaryClass={cs.CL}
}