### PR TITLE
Update list with Yorùbá text from NV-LTI

### DIFF
--- a/list-of-datasets.md
+++ b/list-of-datasets.md
@@ -26,6 +26,7 @@
 |  isiZulu  | | | | [Zulu Bible](https://raw.githubusercontent.com/christos-c/bible-corpus/master/bibles/Zulu-NT.xml) (to be scraped) |
 |  isiZulu  | | | | [Zulu Quoran](http://idmdawah.co.za/wp-content/uploads/2015/07/zulu-quran1.pdf) (to be scraped) |
 |  Igbo     |~384k| | | [Igbo Monolingual](https://github.com/IgnatiusEzeani/IGBONLP/tree/master/ig_monoling)|
+|  Yorùbá | ~626k | 560MB | Various | [Yorùbá Text](https://github.com/Niger-Volta-LTI/yoruba-text) (News, blogs, Bible/Quran/Mormon, proverbs, various books & corpora)  |
 
 
 ## Named Entity Recognition


### PR DESCRIPTION
Adding the [yoruba-text](https://github.com/Niger-Volta-LTI/yoruba-text) repository @ Niger-Volta LTI, which aggregates a dozen or so Yorùbá monolingual text corpora including 

- 2 Bible versions (BSN & Biblica)
- Quran
- Book of Mormon
- Proverbs
- various books (some scanned w/ OCR)
- various corpora
  - LagosNWU corpus, an ASR corpus
  - LangID corpus by Asúbíaró et al
  - Text Embedding corpus by Àlàbí et al.
  - a 2018 scrape of [TheYorubaBlog](https://www.theyorubablog.com) 
  - Universal Declaration of Human Rights in Yorùbá
  - Yorùbá word list (Lexicon)