### PR TITLE
Cleaned Yorùbá Wikipedia dump

### DIFF
--- a/list-of-datasets.md
+++ b/list-of-datasets.md
@@ -27,7 +27,7 @@
 |  isiZulu  | | | | [Zulu Quoran](http://idmdawah.co.za/wp-content/uploads/2015/07/zulu-quran1.pdf) (to be scraped) |
 |  Igbo     |~384k| | | [Igbo Monolingual](https://github.com/IgnatiusEzeani/IGBONLP/tree/master/ig_monoling)|
 |  Yorùbá | ~626k | 560MB | Various | [Yorùbá Text](https://github.com/Niger-Volta-LTI/yoruba-text) (News, blogs, Bible/Quran/Mormon, proverbs, various books & corpora)  |
-
+|  Yorùbá | | 182MB | Various | [Wikipedia dump (cleaned)](https://github.com/tosingithub/ydesk/) (Various articles on science, entertainment, etc.) |
 
 ## Named Entity Recognition
 


### PR DESCRIPTION
This Yorùbá data is the 2020 Wikipedia dump but heavily pre-processed to remove much of the vulgar, html & foreign contents, bringing the original size of 1.6G to 182M.